### PR TITLE
be/fix/53

### DIFF
--- a/backend/src/main/java/com/project4/DailyTask/domain/message/controller/ApiV1MessageController.java
+++ b/backend/src/main/java/com/project4/DailyTask/domain/message/controller/ApiV1MessageController.java
@@ -10,12 +10,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.security.Principal;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -28,9 +30,12 @@ public class ApiV1MessageController {
     @MessageMapping("/team/{teamId}/channel/{channelId}")
     public void handleRoomMessage(@DestinationVariable Long teamId,
                                   @DestinationVariable Long channelId,
-                                  @AuthenticationPrincipal SecurityUser user,
-                                  SendMessageDto messageDto) {
-        messageService.sendMessage(channelId, user, messageDto);
+                                  SendMessageDto messageDto,
+                                  Principal principal
+                                  ) {
+        Authentication authentication = (Authentication) principal;
+        Long userId = (Long) authentication.getPrincipal();
+        messageService.sendMessage(channelId, userId, messageDto);
     }
 
 

--- a/backend/src/main/java/com/project4/DailyTask/domain/message/service/ApiV1MessageService.java
+++ b/backend/src/main/java/com/project4/DailyTask/domain/message/service/ApiV1MessageService.java
@@ -41,14 +41,14 @@ public class ApiV1MessageService {
     private final TeamMemberChecker teamMemberChecker;
 
     @Transactional
-    public void sendMessage(Long channelId, SecurityUser user, SendMessageDto dto){
+    public void sendMessage(Long channelId, Long userId, SendMessageDto dto){
         Channel channel = findChannelOrThrow(channelId);
 
-        User sender = userRepository.findByIdAndStatus(user.getId(), Status.ACTIVE)
+        User sender = userRepository.findByIdAndStatus(userId, Status.ACTIVE)
                 .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
 
         Team team = channel.getTeam();
-        teamMemberChecker.requireJoined(team.getId(), user.getId());
+        teamMemberChecker.requireJoined(team.getId(), userId);
         Message message = Message.createMessage(channel, sender, dto.content(), sender.getNickname(), sender.getId());
         messageRepository.save(message);
         createNotification(team, sender);
@@ -56,7 +56,7 @@ public class ApiV1MessageService {
         MessageRes res = new MessageRes(
                 message.getId(),
                 channelId,
-                new MessageAuthor(user.getId(), user.getNickname()),
+                new MessageAuthor(sender.getId(), sender.getNickname()),
                 message.getContent(),
                 message.getCreatedAt()
         );

--- a/backend/src/main/java/com/project4/DailyTask/domain/message/service/StompAuthChannelInterceptor.java
+++ b/backend/src/main/java/com/project4/DailyTask/domain/message/service/StompAuthChannelInterceptor.java
@@ -47,11 +47,10 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             return message;
         }
 
-        SecurityUser securityUser = extractSecurityUser(accessor);
-
         if (StompCommand.SUBSCRIBE.equals(cmd) || StompCommand.SEND.equals(cmd)) {
+            Long userId = extractUserId(accessor);
             Long teamId = parseTeamId(accessor.getDestination());
-            teamMemberChecker.requireJoined(teamId, securityUser.getId());
+            teamMemberChecker.requireJoined(teamId, userId);
         }
 
         return message;
@@ -93,17 +92,8 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         List<GrantedAuthority> authorities =
                 List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
 
-        SecurityUser securityUser = new SecurityUser(
-                userId,
-                null,
-                null,
-                null,
-                role,
-                authorities
-        );
-
         Authentication authentication = new UsernamePasswordAuthenticationToken(
-                securityUser,
+                userId,
                 null,
                 authorities
         );
@@ -111,7 +101,7 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         accessor.setUser(authentication);
     }
 
-    private SecurityUser extractSecurityUser(StompHeaderAccessor accessor) {
+    private Long extractUserId(StompHeaderAccessor accessor) {
         if (accessor.getUser() == null) {
             throw new ApiException(ErrorCode.INVALID_TOKEN);
         }
@@ -121,11 +111,20 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         }
 
         Object principal = authentication.getPrincipal();
-        if (!(principal instanceof SecurityUser)) {
-            throw new ApiException(ErrorCode.INVALID_TOKEN);
+
+        if (principal instanceof Long userId) {
+            return userId;
         }
 
-        return (SecurityUser) principal;
+        if (principal instanceof String s) {
+            try {
+                return Long.parseLong(s);
+            } catch (NumberFormatException e) {
+                throw new ApiException(ErrorCode.INVALID_TOKEN);
+            }
+        }
+
+        throw new ApiException(ErrorCode.INVALID_TOKEN);
     }
 
     private Long parseTeamId(String destination) {

--- a/backend/src/main/java/com/project4/DailyTask/global/security/auth/SecurityUser.java
+++ b/backend/src/main/java/com/project4/DailyTask/global/security/auth/SecurityUser.java
@@ -23,7 +23,9 @@ public class SecurityUser implements UserDetails {
 
     @Override
     public String getUsername() {
-        return email;
+        return (email != null && !email.isBlank())
+                ? email
+                : String.valueOf(id);
     }
 
     @Override
@@ -47,4 +49,3 @@ public class SecurityUser implements UserDetails {
     }
 
 }
-

--- a/backend/src/main/java/com/project4/DailyTask/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/project4/DailyTask/global/security/config/SecurityConfig.java
@@ -52,9 +52,11 @@ public class SecurityConfig {
                         ).permitAll()
 
                         .requestMatchers("/actuator/health").permitAll()
+                        .requestMatchers("/ws/**").permitAll()
 
 
                         .requestMatchers("/api/**").authenticated()
+                        .anyRequest().permitAll()
 
                 )
 


### PR DESCRIPTION
.withSockJS(); 메서드를 써서 웹소켓이 아닌 환경에서도 가능하게 했는데 ws/** 경로를 열지 않아 403에러 발생

authentiacation.getName()을 식별 키로 쓰는데 시큐리티 유저의 getUsername이 email을 반환하게 해놓고 인터셉터에서 시큐리티 유저를 만들 땐 user 조회없이 jwt에서 얻을 수 있는 값만 전달하려 하다 보니 오류 발생 -> Principal을 Long으로 직접 전달하는 방식으로 변경